### PR TITLE
Fixed Fault with RSA private export

### DIFF
--- a/src/GladLive.Security.Common/RSA/CertToRSAProviderConverter.cs
+++ b/src/GladLive.Security.Common/RSA/CertToRSAProviderConverter.cs
@@ -33,7 +33,7 @@ namespace GladLive.Security.Common
 #endif
 
 #if DNX451 || NET45 || NET451
-			Provider.FromXmlString(cert.PrivateKey.ToXmlString(false));
+			Provider.FromXmlString(cert.PrivateKey.ToXmlString(includePrivateKey));
 #endif
 		}
 	}

--- a/tests/GladLive.Security.Common.Tests/CertToRSAProviderConverterTests.cs
+++ b/tests/GladLive.Security.Common.Tests/CertToRSAProviderConverterTests.cs
@@ -1,0 +1,35 @@
+﻿using GladLive.Security.Common.Tests;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GladLive.Security.Common
+{
+	public class CertToRSAProviderConverterTests
+	{
+		[Fact]
+		public void Test_Ensure_Ctor_Doesnt_Throw_On_Valid_Cert()
+		{
+			//arrange
+			var cert = RSAX509SigningServiceTests.LoadTestCert();
+
+			//act
+			CertToRSAProviderConverter converter = new CertToRSAProviderConverter(cert, true);
+		}
+
+		[Fact]
+		public void Test_Ensure_Includes_Private_Params_If_Requests()
+		{
+			//arrange
+			var cert = RSAX509SigningServiceTests.LoadTestCert();
+
+			//act
+			var rsaCrypto = new CertToRSAProviderConverter(cert, true).Provider;
+
+			//assert:next line shouldn't throw if private was included
+			var rsaparams = rsaCrypto.ExportParameters(true);
+		}
+	}
+}

--- a/tests/GladLive.Security.Common.Tests/RSAX509SigningServiceTests.cs
+++ b/tests/GladLive.Security.Common.Tests/RSAX509SigningServiceTests.cs
@@ -54,7 +54,7 @@ namespace GladLive.Security.Common.Tests
 			Assert.False(signer.isSigned("this should fail", bytes));
 		}
 
-		private static X509Certificate2 LoadTestCert()
+		public static X509Certificate2 LoadTestCert()
 		{
 			byte[] certBytes = null;
 


### PR DESCRIPTION
In CertToRSAProviderConverter if on net45 we didn't export with private
key from cert.

New tests in testing class with similar name covers this case to prevent
a regression.
